### PR TITLE
Use latest standard image

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -58,7 +58,7 @@ Resources:
         Type: no_artifacts
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:2.0
+        Image: aws/codebuild/standard:4.0
         Type: LINUX_CONTAINER
         PrivilegedMode: true
       ServiceRole: !Ref CodeBuildRole


### PR DESCRIPTION
According to https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

standard:2.0 is no longer maintained after June 2020.

So updated to netstandard:4.0. Works just as fine